### PR TITLE
Return id of new duplicated dashboard on copy

### DIFF
--- a/metabase_api/metabase_api.py
+++ b/metabase_api/metabase_api.py
@@ -594,6 +594,8 @@ class Metabase_API():
         self.delete('/api/dashboard/{}/cards'.format(dup_dashboard_id), params={'dashcardId':dash_card_id})
         # adding the new card to the duplicated dashboard
         self.post('/api/dashboard/{}/cards'.format(dup_dashboard_id), json=card_json)
+      
+      return dup_dashboard_id
   
   
   def copy_collection(self, source_collection_name=None, source_collection_id=None, 


### PR DESCRIPTION
We are using this API class to copy dashboards from a template to individual dashboards for customers. For this case we need to store the newly created dashboard's ID in our database. 
This PR adds a return value to `copy_dashboard` which is the ID of the newly created dashboard. This should not break backwards compatibility or anything else.