### PR TITLE
correct collection_id mispelling

### DIFF
--- a/metabase_api/metabase_api.py
+++ b/metabase_api/metabase_api.py
@@ -327,10 +327,10 @@ class Metabase_API():
 
       # setting the collection
       if collection_id:
-        custom_json['collecion_id'] = collection_id
+        custom_json['collection_id'] = collection_id
       elif collection_name:
         collection_id = self.get_collection_id(collection_name)
-        custom_json['collecion_id'] = collection_id
+        custom_json['collection_id'] = collection_id
 
       if complete_json:
         # Adding visualization_settings if it is not present in the custom_json


### PR DESCRIPTION
the mispelling causes the method create_card() to create the card in the wrong collection when custom_json and collection_name/collection_id are provided