### PR TITLE
Fixing copy_dashboard for Metabase hosted in Heroku

### DIFF
--- a/metabase_api/metabase_api.py
+++ b/metabase_api/metabase_api.py
@@ -808,7 +808,7 @@ class Metabase_API():
         except TypeError: 
             # This error happens when res returns false, with a 503 error, when using an Heroku instance.
             # However the dashboard was created. We just need to pick the new dashboard id.
-            sleep(10)
+            sleep(20)
             dashboards = self.get("/api/dashboard/")
             dup_dashboard_id = sorted([x for x in dashboards if x['name'] == destination_dashboard_name], key=lambda k: k['created_at'], reverse=True)[0]['id']
 

--- a/metabase_api/metabase_api.py
+++ b/metabase_api/metabase_api.py
@@ -808,7 +808,7 @@ class Metabase_API():
         except TypeError: 
             # This error happens when res returns false, with a 503 error, when using an Heroku instance.
             # However the dashboard was created. We just need to pick the new dashboard id.
-            sleep(3)
+            sleep(10)
             dashboards = self.get("/api/dashboard/")
             dup_dashboard_id = sorted([x for x in dashboards if x['name'] == destination_dashboard_name], key=lambda k: k['created_at'], reverse=True)[0]['id']
 


### PR DESCRIPTION
When the dashboard contains too many cards/questions, the function copy_dashboard fails.

What happens is: the variable "res" does not return a json and therefore the variable "dup_dashboard_id" raises a TypeError.
Despite of "res" returns false, the dashboard was indeed created in Metabase.

Therefore, if we could obtain the "dup_dashboard_id", we could move on inside the function and do a deep_copy.

The solution I found was to get all dashboards and pick the last one we created and select the id.
