### PR TITLE
chore: update regexp to treat string as raw, eliminating warnings

### DIFF
--- a/metabase_api/metabase_api.py
+++ b/metabase_api/metabase_api.py
@@ -208,7 +208,7 @@ class Metabase_API():
             
             # find column IDs
             import re
-            res = re.findall("\['field', .*?\]", query_data_str)
+            res = re.findall(r"\['field', .*?\]", query_data_str)
             source_column_IDs = [ eval(i)[1] for i in res ]
             
             # replace column IDs from old table with the column IDs from new table


### PR DESCRIPTION
Fixes: #57 

This PR attempts to fix a `SyntaxWarning` that's raised from the library due to an invalid escape sequence in the pattern used in `re.findall()`

The backslash before the square bracket in the string was not being handled properly. This is resolved by prefixing it with `r`, suring that the backslash is treated literally. 

# error output
```
/venv/lib/python3.12/site-packages/metabase_api/metabase_api.py:211: SyntaxWarning: invalid escape sequence '\['
  res = re.findall("\['field', .*?\]", query_data_str)
```